### PR TITLE
 Enhance Release Number Calculation to Ensure Auto-Increment #1 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: C/C++ patch CI
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         if [ "${{ env.latest_release }}" = "null" ]; then
           echo "new_version=0.1.0" >> $GITHUB_ENV
         else
-          IFS='.' read -r major minor patch <<< "${{ env.latest_release#v }}"
+          IFS='.' read -r major minor patch <<< "${{ env.latest_release }}"
           patch=$((patch + 1))
           new_version="$major.$minor.$patch"
           echo "new_version=$new_version" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,28 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Get commit count
-      id: get_commit_count
+    # - name: Get commit count
+    #   id: get_commit_count
+    #   run: |
+    #     COMMIT_COUNT=$(git rev-list --count HEAD)
+    #     echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
+    - name: Get latest release
+      id: get_latest_release
       run: |
-        COMMIT_COUNT=$(git rev-list --count HEAD)
-        echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
+        latest_release=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+        echo "latest_release=${latest_release}" >> $GITHUB_ENV
+
+    - name: Determine next version
+      id: next_version
+      run: |
+        if [ "${{ env.latest_release }}" = "null" ]; then
+          echo "new_version=0.1.0" >> $GITHUB_ENV
+        else
+          IFS='.' read -r major minor patch <<< "${{ env.latest_release#v }}"
+          patch=$((patch + 1))
+          new_version="$major.$minor.$patch"
+          echo "new_version=$new_version" >> $GITHUB_ENV
+        fi
 
     - name: Create release directory
       run: |
@@ -80,9 +97,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
-        tag_name: "v${{ steps.get_commit_count.outputs.commit_count }}"
-        name: "Release v${{ steps.get_commit_count.outputs.commit_count }}"
-        body: "Release for commit number ${{ steps.get_commit_count.outputs.commit_count }}"
+        tag_name: "v${{ env.new_version }}"
+        name: "Release v${{ env.new_version }}"
+        body: "Release for commit number v${{ env.new_version }}"
         files: |
           release.zip
           release.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: C/C++ CI
 on:
   push:
     branches: [ main ]
+    tags-ignore: 
+      - '*'  # Ignore all tag pushes
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     tags-ignore: 
-      - '*'  # Ignore all tag pushes
+      - 'v*'  # Ignore all tag pushes
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
     tags-ignore: 
-      - 'v*'  # Ignore all tag pushes
+      - 'v*'  # Ignore all tag version pushes
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    # - name: Get commit count
-    #   id: get_commit_count
-    #   run: |
-    #     COMMIT_COUNT=$(git rev-list --count HEAD)
-    #     echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
     - name: Get latest release
       id: get_latest_release
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       id: next_version
       run: |
         if [ "${{ env.latest_release }}" = "null" ]; then
-          echo "new_version=0.1.0" >> $GITHUB_ENV
+          echo "new_version=v0.1.0" >> $GITHUB_ENV
         else
           IFS='.' read -r major minor patch <<< "${{ env.latest_release }}"
           patch=$((patch + 1))
@@ -99,9 +99,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
-        tag_name: "v${{ env.new_version }}"
-        name: "Release v${{ env.new_version }}"
-        body: "Release for commit number v${{ env.new_version }}"
+        tag_name: "${{ env.new_version }}"
+        name: "Release ${{ env.new_version }}"
+        body: "Release for commit number ${{ env.new_version }}"
         files: |
           release.zip
           release.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     branches: [ main ]
     tags:
       - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
-    tags-ignore:
-      - main # Excluding as it is a edge case for github actions tags
+      - '!main'
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
     tags-ignore:
-      - main # Excluding as it is a edge case for github actions tags 
+      - main # Excluding as it is a edge case for github actions tag
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: C/C++ Major/Minor Release CI
 
 on:
   push:
@@ -77,9 +77,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       with:
-        tag_name: "v${{ github.ref_name }}"
-        name: "Release v${{ github.ref_name }}"
-        body: "Release for commit number v${{ github.ref_name }}"
+        tag_name: "${{ github.ref_name }}"
+        name: "Release ${{ github.ref_name }}"
+        body: "Release for commit number ${{ github.ref_name }}"
         files: |
           release.zip
           release.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
     tags:
       - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
+    tags-ignore:
+      - main # Excluding as it is a edge case for github actions tags 
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
     tags-ignore:
-      - main # Excluding as it is a edge case for github actions tag
+      - main # Excluding as it is a edge case for github actions tags
   pull_request:
     branches: [ main ]
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,8 @@ name: C/C++ Major/Minor Release CI
 
 on:
   push:
-    branches: [ main ]
     tags:
       - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
-      - '!main'
-  pull_request:
-    branches: [ main ]
   release:
     types: [created]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*.*.*'  # Trigger the workflow on version tags like v1.0.0
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [created]
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Cache CMake and build files
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache
+          build
+        key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-cmake-
+
+    - name: Install C++ build tools and dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake g++ make build-essential --no-install-recommends
+
+    - name: Configure CMake
+      run: |
+        mkdir -p build
+        cmake -S . -B build
+
+    - name: Build the project
+      run: |
+        cmake --build build
+
+    - name: Run unit tests
+      run: |
+        ctest --test-dir build --output-on-failure
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+   
+    - name: Create release directory
+      run: |
+        mkdir release
+        shopt -s extglob
+        cp -r !(release) release/
+
+    - name: Create release zip file
+      run: |
+        cd release
+        zip -r ../release.zip .
+
+    - name: Create release tarball file
+      run: |
+        cd release
+        tar -czvf ../release.tar.gz .
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      with:
+        tag_name: "v${{ github.ref_name }}"
+        name: "Release v${{ github.ref_name }}"
+        body: "Release for commit number v${{ github.ref_name }}"
+        files: |
+          release.zip
+          release.tar.gz


### PR DESCRIPTION
Separated CI for patch version = incremental on each commit
and minor/major version = commit with tag

minor/major version can be released as below :

`
git commit -m "Commit changes before major/minor release"
git tag -a v1.2.0 -m "Releasing version 1.2.0 (tagging the new version)"
git push origin v1.2.0
`

to sync the same code to main branch:

`git push origin main`

push the current code to main branch
